### PR TITLE
retrieve default profile like twurl

### DIFF
--- a/ton_upload
+++ b/ton_upload
@@ -26,26 +26,15 @@ RestClient.log = Logger.new(STDERR)
 
 API_DOMAIN = "ton.twitter.com"
 
-CONSUMER_KEY = begin
-  profile = Twurl::RCFile.load["configuration"]
-  key = profile["default_profile"][1]
-  key.nil? ? nil : key
+DEFAULT_PROFILE = begin
+  default = Twurl::RCFile.load["configuration"]["default_profile"]
+  profile = Twurl::OAuthClient.load_client_for_username_and_consumer_key(default[0], default[1])
 end
 
-CONSUMER_SECRET = begin
-  name, profiles = Twurl::RCFile.load["profiles"].detect {|k, v| v.include?(CONSUMER_KEY) }
-  profiles.nil? ? nil : profiles[CONSUMER_KEY]["consumer_secret"]
-end
-
-USER_TOKEN = begin
-  name, profiles = Twurl::RCFile.load["profiles"].detect {|k, v| v.include?(CONSUMER_KEY) }
-  profiles.nil? ? nil : profiles[CONSUMER_KEY]["token"]
-end
-
-USER_SECRET = begin
-  name, profiles = Twurl::RCFile.load["profiles"].detect {|k, v| v.include?(CONSUMER_KEY) }
-  profiles.nil? ? nil : profiles[CONSUMER_KEY]["secret"]
-end
+CONSUMER_KEY    = DEFAULT_PROFILE.consumer_key
+CONSUMER_SECRET = DEFAULT_PROFILE.consumer_secret
+USER_TOKEN      = DEFAULT_PROFILE.token
+USER_SECRET     = DEFAULT_PROFILE.secret
 
 MISSING_SECRET_ERROR = "Your ~/.twurlrc does not contain a consumer secret " +
   "for the test application (#{CONSUMER_KEY}). Follow the twurl setup " +


### PR DESCRIPTION
This patch fixes the following issue.
  
ton_upload doesn't use "default" profile under a specific condition where
- There are multiple profiles with the same consumer key in .twurlrc.
- And the "default" profile data is not located on the beginning among the same cousumer key profiles.
 
Reproduce steps:
1. prepare empty .twurlrc
2. twurl authorize --consumer-key xxxxxxxx --consumer-secret yyyyyyyyyy
3. complete username1 authorization
4. twurl authorize --consumer-key xxxxxxxx --consumer-secret yyyyyyyyyy
5. complete username2 authorization
6. twurl set default username2
7. edit the token of username1 to set invalid value in .twurlrc
8. execute ton_upload adding -t option like
  $ ruby ton_upload -t -b ta_parter -m upload -f test.txt
 
-> The response is 403 forbidden
-> The value of oauth_token in the POST reqeust header is username1's one