### PR TITLE
[minor] handling error when .twurlrc is not present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,7 @@ build/
 /.bundle/
 /lib/bundler/man/
 
-# for a library or gem, you might want to ignore these files since the code is
-# intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
-
-# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+Gemfile.lock
+.ruby-version
+.ruby-gemset
 .rvmrc

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem "json"
 gem "logger"
 gem "mime-types", "~> 2.0", :require => "mime/types"
 gem "oauth"
-gem "rest_client"
+gem "rest-client"
 gem "twurl", "~> 0.9.0"
 

--- a/ton_upload
+++ b/ton_upload
@@ -16,7 +16,7 @@ require 'digest/md5'
 require 'json'
 require 'logger'
 require 'mime/types'
-require 'rest_client'
+require 'rest-client'
 require 'twurl'
 require 'time'
 require 'optparse'
@@ -26,21 +26,27 @@ RestClient.log = Logger.new(STDERR)
 
 API_DOMAIN = "ton.twitter.com"
 
-DEFAULT_PROFILE = begin
+MISSING_TWURL_CONFIG = "[ERROR] Your ~/.twurlrc could not be found. " +
+  "Please install and setup twurl then try again: \n\n" +
+  "  gem install twurl\n" +
+  "  twurl authorize --consumer-key key --consumer-secret secret\n\n"
+
+TWURL_PROFILE = begin
   default = Twurl::RCFile.load["configuration"]["default_profile"]
+  abort MISSING_TWURL_CONFIG unless default
   profile = Twurl::OAuthClient.load_client_for_username_and_consumer_key(default[0], default[1])
 end
 
-CONSUMER_KEY    = DEFAULT_PROFILE.consumer_key
-CONSUMER_SECRET = DEFAULT_PROFILE.consumer_secret
-USER_TOKEN      = DEFAULT_PROFILE.token
-USER_SECRET     = DEFAULT_PROFILE.secret
+CONSUMER_KEY    = TWURL_PROFILE.consumer_key
+CONSUMER_SECRET = TWURL_PROFILE.consumer_secret
+USER_TOKEN      = TWURL_PROFILE.token
+USER_SECRET     = TWURL_PROFILE.secret
 
-MISSING_SECRET_ERROR = "Your ~/.twurlrc does not contain a consumer secret " +
+MISSING_SECRET_ERROR = "[ERROR] Your ~/.twurlrc does not contain a consumer secret " +
   "for the test application (#{CONSUMER_KEY}). Follow the twurl setup " +
   "instructions and try again."
 
-MISSING_TOKEN_ERROR = "Your ~/.twurlrc does not contain a user token " +
+MISSING_TOKEN_ERROR = "[ERROR] Your ~/.twurlrc does not contain a user token " +
   "and secret for the application (#{CONSUMER_KEY}). Follow the twurl setup " +
   "instructions and try again."
 


### PR DESCRIPTION
* Handling error / showing message when .twurlrc is not present and setup.
* Adding Gemfile.lock to the .gitignore file.
* Updating deprecated rest_client to rest-client (drop in replacement).